### PR TITLE
Tiki Trackers and Tiki's Wiki Engine as alternatives

### DIFF
--- a/public/products.json
+++ b/public/products.json
@@ -147,6 +147,14 @@
       "subscription": "Yes (Free CE)",
       "license": "AGPL-3.0",
       "marketplace": "No"
+    },
+    {
+      "title": "Tiki's Wiki Engine",
+      "link": "https://doc.tiki.org/Wiki/",
+      "hosting": "Cloud / On Premise",
+      "subscription": "No (Free)",
+      "license": "LGPLv2.1",
+      "marketplace": "No"
     }
   ]
 }

--- a/public/products.json
+++ b/public/products.json
@@ -47,6 +47,14 @@
       "subscription": "Yes (On Premise free)",
       "license": "Apache 2.0",
       "marketplace": "No"
+    },
+    {
+      "title": "Tiki Trackers",
+      "link": "https://tikitrackers.org/",
+      "hosting": "Cloud / On Premise",
+      "subscription": "No (Free)",
+      "license": "LGPLv2.1",
+      "marketplace": "No"
     }
   ],
   "jiraservicedesk": [

--- a/public/products.json
+++ b/public/products.json
@@ -89,6 +89,14 @@
       "subscription": "Yes (Free CE)",
       "license": "MIT",
       "marketplace": "Yes"
+    },
+    {
+      "title": "Tiki Trackers",
+      "link": "https://tikitrackers.org/",
+      "hosting": "Cloud / On Premise",
+      "subscription": "No (Free)",
+      "license": "LGPLv2.1",
+      "marketplace": "No"
     }
   ],
   "confluence": [


### PR DESCRIPTION
- Tiki Trackers as alternative to Jira Software
- Tiki Trackers as alternative to Jira Service Desk 
- Tiki's Wiki Engine as alternative to Confluence