### PR TITLE
Remove Phabricator from Jira software alternatives

### DIFF
--- a/public/products.json
+++ b/public/products.json
@@ -49,14 +49,6 @@
       "marketplace": "No"
     },
     {
-      "title": "Phabricator",
-      "link": "https://www.phacility.com/phabricator/",
-      "hosting": "Cloud, On Premises",
-      "subscription": "Yes (On Premises free)",
-      "license": "Apache 2.0",
-      "marketplace": "No"
-    },
-    {
       "title": "Taiga",
       "link": "https://www.taiga.io/",
       "hosting": "Cloud, On Premises (on request)",


### PR DESCRIPTION
Phabricator is no longer actively maintained [1][2] and is therefore no real alternative.

[1] https://github.com/phacility/phabricator/commit/9ceb66453501d461800617b9fb2d4af4ba2c9514
[2] https://admin.phacility.com/phame/post/view/11/phacility_is_winding_down_operations/