### PR TITLE
Update rebranded Easy8 entry in Jira Software alternatives

### DIFF
--- a/src/lib/data/products.js
+++ b/src/lib/data/products.js
@@ -1,16 +1,8 @@
 export const products = {
   jirasoftware: [
     {
-      title: 'EasyProject',
-      link: 'https://www.easyproject.com',
-      hosting: 'Cloud / On Premises',
-      subscription: 'Yes',
-      license: 'Proprietary',
-      marketplace: 'No',
-    },
-    {
-      title: 'EasyRedmine',
-      link: 'https://www.easyredmine.com',
+      title: 'Easy8',
+      link: 'https://www.easy8.com',
       hosting: 'Cloud / On Premises',
       subscription: 'Yes',
       license: 'Proprietary',


### PR DESCRIPTION
## What

Replaces the **EasyProject** and **EasyRedmine** entries in the Jira Software alternatives list with a single **Easy8** entry.

## Why

Both products were rebranded and consolidated into **Easy8** (https://www.easy8.com) in March 2026. The old domains now permanently redirect there:

- `https://www.easyproject.com` → `https://www.easy8.com/`
- `https://www.easyredmine.com` → `https://www.easy8.com/`

Keeping two separate cards pointing at redirecting domains is misleading for visitors, so this merges them into one up-to-date entry. All other attributes (Cloud / On Premises hosting, subscription, proprietary license, no marketplace) remain accurate for Easy8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)